### PR TITLE
Fix typo introduced Jul 14 2015

### DIFF
--- a/extlib/xmlseclibs/xmlseclibs.php
+++ b/extlib/xmlseclibs/xmlseclibs.php
@@ -47,7 +47,7 @@ class XMLSecurityKey {
     const AES256_CBC = 'http://www.w3.org/2001/04/xmlenc#aes256-cbc';
     const RSA_1_5 = 'http://www.w3.org/2001/04/xmlenc#rsa-1_5';
     const RSA_OAEP_MGF1P = 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p';
-    const DSA_SHA1 = 'http://www.w3.org/2000/09/xmld/sig#dsa-sha1';
+    const DSA_SHA1 = 'http://www.w3.org/2000/09/xmldsig#dsa-sha1';
     const RSA_SHA1 = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1';
     const RSA_SHA256 = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
     const RSA_SHA384 = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha384';


### PR DESCRIPTION
Just noticed this while looking at the code.

Verified that https://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd#dsa-sha1 is correct and https://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmld/sig-core-schema.xsd#dsa-sha1 goes to a 404 page
